### PR TITLE
Enforces consistent line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Files that should use LF line endings
+[*.{sql,sh}]
+end_of_line = lf
+
+[Dockerfile]
+end_of_line = lf
+
+# Files that should not have a final newline
+[*.md]
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Let git handle line endings automatically
+* text=auto
+
+# normalize these line endings to LF
+*.sql text eol=lf
+Dockerfile text eol=lf
+*.sh text eol=lf
+
+# ensure these files are always treated as binary
+*.png binary
+*.jpg binary
+*.ico binary


### PR DESCRIPTION
Hey @CarlSargunar, as we discussed at the workshop...

Adding the `.gitattributes` file lets us make sure certain file types use LF or CRLF on checkout. Setting the default to auto helps make the line endings on checkout more predictable (note, when doing this we need to explicitly then tell git which files it should treat as binary too).

Amongst other things, the `.editorconfig` will make supported editors use LF as the default when new files of that type are created.\

To test, check this out on Windows and see how the LF line endings are preserved.